### PR TITLE
Add discord link to Community menu

### DIFF
--- a/resources/views/partials/header.edge
+++ b/resources/views/partials/header.edge
@@ -51,6 +51,9 @@
                 title: 'Gitter', href: 'https://gitter.im/adonisjs/adonis-framework'
               },
               {
+                title: 'Discord', href: 'https://discord.gg/k5myGAz'
+              },
+              {
                 title: 'Donate', href: 'https://www.patreon.com/adonisframework'
               }
             ]

--- a/resources/views/partials/header.edge
+++ b/resources/views/partials/header.edge
@@ -48,9 +48,6 @@
                 title: 'Blog', href: 'https://adonisjs.svbtle.com'
               },
               {
-                title: 'Gitter', href: 'https://gitter.im/adonisjs/adonis-framework'
-              },
-              {
                 title: 'Discord', href: 'https://discord.gg/k5myGAz'
               },
               {


### PR DESCRIPTION
Now that the main chat communication solution has moved from Gitter to Discord, I've added the Discord invite link to the Community drop-down so that people are more easily able to join the discussion.

For the time being, I was thinking that you could leave the Gitter link, so that people are able to go to the Gitter and see the last message indicating that they should move to Discord, to help reduce confusion.

I can add another commit to remove Gitter though if that's what you want to do.