### PR TITLE
Remove last admonition paragraph bottom margin

### DIFF
--- a/resources/sass/_wysiwyg.scss
+++ b/resources/sass/_wysiwyg.scss
@@ -350,6 +350,10 @@
         background: linear-gradient(to right,#6100e9,#4800ad);
       }
     }
+    
+    .paragraph:last-child {
+      margin-bottom: 0;
+    }
   }
 
   .toc {


### PR DESCRIPTION
This pull requests removes the `margin-bottom` from the last `.paragraph` in an `.admonitionblock`.

Prior to this pull request, a multi-paragraph admonition would render with a large space under its last paragraph:

![admonition-before](https://user-images.githubusercontent.com/1914481/47063449-b4e07800-d226-11e8-8c39-327f70ad336d.png)

With this change, that large space is now removed:

![admonition-after](https://user-images.githubusercontent.com/1914481/47063452-b873ff00-d226-11e8-9c55-0f4d18c77365.png)

Cheers!