### PR TITLE
Make groups somehow visible on mobile devices

### DIFF
--- a/resources/views/partials/sidebar.edge
+++ b/resources/views/partials/sidebar.edge
@@ -28,7 +28,7 @@
     <select id="docs-switch">
       <option value=""> Select A Topic </option>
       @each((items, group) in menu)
-        <option value=""> --- </option>
+        <option value=""> --- {{ humanize(group) }}</option>
         @each(item in items)
           <option value="{{ item.permalink }}" {{ item.permalink === doc.permalink ? 'selected' : '' }}>
             {{ item.title }}

--- a/resources/views/partials/sidebar.edge
+++ b/resources/views/partials/sidebar.edge
@@ -28,6 +28,7 @@
     <select id="docs-switch">
       <option value=""> Select A Topic </option>
       @each((items, group) in menu)
+        <option value=""> --- </option>
         @each(item in items)
           <option value="{{ item.permalink }}" {{ item.permalink === doc.permalink ? 'selected' : '' }}>
             {{ item.title }}


### PR DESCRIPTION
It annoys me that I can’t distinguish groups of items, names like ‘Getting started’ are really confusing (comparing to for example ‘Getting started with testing’, this makes it just a bit more intuitive