### PR TITLE
Fixed a wrong word in Lucid ORM relationship Doc

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2877,8 +2877,7 @@
     "cssom": {
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.6.tgz",
-      "integrity": "sha512-DtUeseGk9/GBW0hl0vVPpU22iHL6YB5BUX7ml1hB+GMpo0NX5G4voX3kdWiMSEguFtcW3Vh3djqNF4aIe6ne0A==",
-      "optional": true
+      "integrity": "sha512-DtUeseGk9/GBW0hl0vVPpU22iHL6YB5BUX7ml1hB+GMpo0NX5G4voX3kdWiMSEguFtcW3Vh3djqNF4aIe6ne0A=="
     },
     "cssstyle": {
       "version": "0.2.37",
@@ -6773,8 +6772,7 @@
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
-      "optional": true
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
     },
     "prepend-http": {
       "version": "2.0.0",
@@ -9010,7 +9008,6 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-      "optional": true,
       "requires": {
         "prelude-ls": "~1.1.2"
       }


### PR DESCRIPTION
This PR corrects a minor mistake in Lucid ORM doc:
In Defining Relationship example:
If the **Post** model does not exist, generate it:
shoud be: If the **Profile** model does not exist, generate it:
Because the the coding example given below that line is of Profile not Post.