### PR TITLE
Clean up non-existent or archived community packages

### DIFF
--- a/resources/views/packages.edge
+++ b/resources/views/packages.edge
@@ -91,7 +91,7 @@
           </div>
 
           <div class="app-card is-row">
-            <h3 class="is-size-5"> <a href="https://github.com/poppinss/anchorify" target="_blank"> anchorify </a> </h3>
+            <h3 class="is-size-5"> <a href="https://github.com/poppinss/anchorify" target="_blank"> anchorify <span class="subtitle">(archived)</span> </a> </h3>
             <p> Convert URLs to anchor tags inside a string. </p>
           </div>
 

--- a/resources/views/packages.edge
+++ b/resources/views/packages.edge
@@ -44,10 +44,6 @@
       <div class="shrinked-container">
         <h3 class="is-size-4"> All other packages </h3>
         <div class="packages-list">
-          <div class="app-card is-row">
-            <h3 class="is-size-5"> <a href="https://github.com/poppinss/node-req" target="_blank"> node-req </a> </h3>
-            <p> I/O module to make native HTTP <code>req</code> object more useful. </p>
-          </div>
 
           <div class="app-card is-row">
             <h3 class="is-size-5"> <a href="https://github.com/poppinss/node-cookie" target="_blank"> node-cookie </a> </h3>


### PR DESCRIPTION
Cleaned up the official packages subpage.

- Removed node-req since it doesn't exist anymore (at least I didn't manage to find it on a different URL),
- Added archived tag to _anchorify_, since it is archived on GitHub.