### PR TITLE
Removes broken screencast link

### DIFF
--- a/resources/views/screencasts.edge
+++ b/resources/views/screencasts.edge
@@ -32,19 +32,6 @@
 
           <div class="column is-4">
             @component('components.screencast',
-              image = 'https://i.vimeocdn.com/video/676185529.jpg?mw=1500&mh=3000&q=70',
-              position = '-25px 16px',
-              title = 'Adonis 4, From Scratch to Sass',
-              url = 'https://www.bahdcasts.com/courses/adonis-4-from-scratch-to-saas'
-            )
-              <p>
-                A beginner-friendly series of screencasts handholding you to create a pratical working application from scratch.
-              </p>
-            @endcomponent
-          </div>
-
-          <div class="column is-4">
-            @component('components.screencast',
               image = 'http://res.cloudinary.com/adonisjs/image/upload/q_100/v1521629831/codecourse-adonis_nylt0m.jpg',
               position = '50% 50%',
               url = 'https://www.codecourse.com/lessons/build-a-forum-with-adonis-js'


### PR DESCRIPTION
It apepars that bahdcasts.com no longer exists.
It forwards to another domain and there is no way to access the courses,
so removing broken link