### PR TITLE
style: fix scorllBar to make it auto visible (Without formatting)

### DIFF
--- a/frontend/src/components/Guides/Sidebar.vue
+++ b/frontend/src/components/Guides/Sidebar.vue
@@ -88,7 +88,7 @@
 
   .sidebar-container {
     height: 100%;
-    overflow: scroll;
+    overflow: auto;
     width: 250px;
     padding: 0;
   }

--- a/frontend/src/components/Guides/Toc.vue
+++ b/frontend/src/components/Guides/Toc.vue
@@ -27,7 +27,7 @@
   .toc-content {
     height: 100%;
     width: 300px;
-    overflow: scroll;
+    overflow: auto;
     padding: 60px 90px 60px 55px;
   }
 

--- a/frontend/src/components/Home/CodeGroup.vue
+++ b/frontend/src/components/Home/CodeGroup.vue
@@ -66,7 +66,7 @@
 
 <style scoped>
   .hero-codegroup-tabs {
-    overflow: scroll;
+    overflow: auto;
     position: relative;
   }
 

--- a/frontend/src/components/Home/SecondaryFeatures.vue
+++ b/frontend/src/components/Home/SecondaryFeatures.vue
@@ -100,7 +100,7 @@
   .features-list-nav {
     padding: 40px 0;
     display: flex;
-    overflow: scroll;
+    overflow: auto;
   }
 
   .features-list-nav div {


### PR DESCRIPTION
make the scrollBar of the following component 'auto' instead of 'scroll' to hide unnecessary scrollers. and keep the ability for the scrollBar visible in case of a long list contents. 