### PR TITLE
Fix page jumping when clicking dropdown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+.idea
 *.log
 
 frontend/node_modules

--- a/frontend/src/components/Guides/Sidebar.vue
+++ b/frontend/src/components/Guides/Sidebar.vue
@@ -32,7 +32,7 @@
               href="#"
               class="dropdown-selected-item"
               :title="group"
-              @click="isExpanded = !isExpanded"
+              @click.prevent="isExpanded = !isExpanded"
             >
               <span>{{ group }}</span>
               <svg width="8" height="6" viewBox="0 0 8 6" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M.94.727l-.94.94 4 4 4-4-.94-.94L4 3.78.94.727z" fill="currentColor"/></svg>


### PR DESCRIPTION
On a guide page, when you click a link on the right side, the page jumps to the linked section using an anchor (e.g. `#creating-a-new-project`). However, the dropdown in the sidebar uses an empty anchor link (`#`). So when you click it, instead of opening the dropdown, the anchor gets reset and the page jumps to the top ([gif](https://gyazo.com/72f43f272f7d6ac8e66c72ce29281ce5)). You then have to click the dropdown again to actually open it.

This PR fixes that issue by adding `.prevent` to the click handler of the dropdown box.