### PR TITLE
docs: Fix peform typo on routing

### DIFF
--- a/docs/docs/guides/01-basics/02-http/02-routing.md
+++ b/docs/docs/guides/01-basics/02-http/02-routing.md
@@ -150,19 +150,19 @@ Route.post('/posts', async () => {
 })
 
 Route.get('/posts', () => {
-  return 'Peform Read'
+  return 'Perform Read'
 })
 
 Route.get('/posts/:id', () => {
-  return 'Peform Read on a single post'
+  return 'Perform Read on a single post'
 })
 
 Route.put('/posts/:id', () => {
-  return 'Peform Update'
+  return 'Perform Update'
 })
 
 Route.delete('/posts/:id', () => {
-  return 'Peform Delete'
+  return 'Perform Delete'
 })
 ```
 


### PR DESCRIPTION
Fix typo in Routing docs by replacing peform with perform