### PR TITLE
fix: replace index.js to index.ts in Factories

### DIFF
--- a/docs/docs/guides/04-database/06-factories.md
+++ b/docs/docs/guides/04-database/06-factories.md
@@ -19,7 +19,7 @@ Model factories are stored inside `databases/factories` directory. You can defin
 
 Unlike seeders or models, the factories are declarative in nature as shown in the following example:
 
-```ts{}{database/factories/index.js}
+```ts{}{database/factories/index.ts}
 import Factory from '@ioc:Adonis/Lucid/Factory'
 import User from 'App/Models/User'
 


### PR DESCRIPTION
There is a typo error in Factories docs, index file must be `index.ts` and not `index.js`, because it throws compiling errors.