### PR TITLE
Build needs to be run before running migration script

### DIFF
--- a/docs/docs/guides/database/05-migrations.md
+++ b/docs/docs/guides/database/05-migrations.md
@@ -73,11 +73,19 @@ export default class Users extends BaseSchema {
 }
 ```
 
-Next, you will need run the following ace command to build the application:
+[note]
+
+Migrations are executed against the compiled Javascript code. So, make sure to run one of the following ace commands to keep the compiled output upto date.
 
 ```sh
-node ace build
+# watch & re-compile
+node ace build --watch
+
+# watch, re-compile & start http server
+node ace serve --watch
 ```
+
+[/note]
 
 Finally, run the following ace command to execute the instructions for creating the `users` table.
 

--- a/docs/docs/guides/database/05-migrations.md
+++ b/docs/docs/guides/database/05-migrations.md
@@ -73,6 +73,12 @@ export default class Users extends BaseSchema {
 }
 ```
 
+Next, you will need run the following ace command to build the application:
+
+```sh
+node ace build
+```
+
 Finally, run the following ace command to execute the instructions for creating the `users` table.
 
 ```sh


### PR DESCRIPTION
In the Database Migration Docs, adding a note that says a build needs to be done before running a migration, otherwise, you can end up with an error where the database configuration is out of date

I also see a change on the note on data loss but I'm not sure why it's showing a change, doesn't look like anything is actually changed on that line

In reference to an issue I encountered in [this discussion](https://github.com/adonisjs/core/discussions/1337)