### PR TITLE
Fix typo 08-factories.md

### DIFF
--- a/docs/docs/guides/database/08-factories.md
+++ b/docs/docs/guides/database/08-factories.md
@@ -123,7 +123,7 @@ export const PostFactory = Factory
 export const UserFactory = Factory
   .define(User, ({ faker }) => {
     return {
-      username: faker.internet.username(),
+      username: faker.internet.userName(),
       email: faker.internet.email(),
       password: faker.internet.password(),
     }


### PR DESCRIPTION
Property `faker.internet.username()` doesn't exist, but `faker.internet.userName()` does.
(Same issue than #95, I went a bit too fast and didn't check if there were multiple occurrences...)