### PR TITLE
Apply middleware to route resources

### DIFF
--- a/docs/docs/guides/01-basics/03-http/02-routing.md
+++ b/docs/docs/guides/01-basics/03-http/02-routing.md
@@ -412,7 +412,7 @@ The `Route.resource` method also exposes the API to register middleware on all o
 ```ts
 Route
   .resource('users', 'UsersController')
-  .middleware('auth')
+  .middleware({'*': ['auth']})
 ```
 
 When selectively applying middleware to certain routes, the object **key is the name of the route** and **value is an array of middleware** to apply.

--- a/docs/docs/guides/01-basics/03-http/02-routing.md
+++ b/docs/docs/guides/01-basics/03-http/02-routing.md
@@ -412,7 +412,7 @@ The `Route.resource` method also exposes the API to register middleware on all o
 ```ts
 Route
   .resource('users', 'UsersController')
-  .middleware({'*': ['auth']})
+  .middleware({ '*': ['auth'] })
 ```
 
 When selectively applying middleware to certain routes, the object **key is the name of the route** and **value is an array of middleware** to apply.


### PR DESCRIPTION
The current way to apply a middleware to a route resources leads to a ts error.