### PR TITLE
Fix typos in ORM guides.

### DIFF
--- a/docs/docs/guides/database/03-orm/04-hooks.md
+++ b/docs/docs/guides/database/03-orm/04-hooks.md
@@ -7,7 +7,7 @@ group: Database
 # Hooks
 Hooks are the actions that you can perform during a pre-defined life cycle event. Using hooks, you can encapsulate certain actions within your models vs writing them everywhere inside the codebase.
 
-A great example of hooks is password hashing. Instead of hashing the user password everywhere inside your codebase, you can write it as a hook and the guarantee that user passwords will be persisted as plain text.
+A great example of hooks is password hashing. Instead of hashing the user password everywhere inside your codebase, you can write it as a hook and then guarantee that user passwords will be persisted as plain text.
 
 ## Creating your first hook
 Lets build on the password hashing example and define a hook to hash the user password before saving it to the database.

--- a/docs/docs/guides/database/03-orm/06-serializing-models.md
+++ b/docs/docs/guides/database/03-orm/06-serializing-models.md
@@ -230,7 +230,7 @@ export class User extends BaseModel {
 ## Computed properties
 As stated earlier, the `serialize` method ignores all the model properties except the one using the `@column` decorator. 
 
-There will be times, when you want to include custom properties inside the serialized output, but without defining them inside the database, and this is where the computed properties comes into the picture.
+There will be times, when you want to include custom properties inside the serialized output, but without defining them inside the database, and this is where the computed properties come into the picture.
 
 [note]
 The serialization process is synchronous and hence you cannot use `async/await` on the computed properties.


### PR DESCRIPTION
I think the change in `06-serializing-models.md` is valid because as the `computed properties` text is in plural form then it should be `come` instead of `comes`.