### PR TITLE
docs(rules): add commas to code snippet

### DIFF
--- a/docs/docs/guides/validator/04-validation-rules.md
+++ b/docs/docs/guides/validator/04-validation-rules.md
@@ -4,9 +4,11 @@ group: Validator
 ---
 
 # Validation Rules
+
 Validation rules allows adding additional constraints on the schema types. For example: A rule to validate the formatting of a string to be a valid email, and another rule to ensure a field value is unique inside the database.
 
 ## Importing and using rules
+
 The first step is to import the `rules` list.
 
 ```ts
@@ -23,13 +25,14 @@ schema.create({
   email: schema.string({}, [
     // highlight-start
     rules.email(),
-    rules.unique({ table: 'users', column: 'email' })
+    rules.unique({ table: 'users', column: 'email' }),
     // highlight-end
-  ])
+  ]),
 })
 ```
 
 ## `rules.alpha`
+
 Enforces the value to only have letters. Optionally, you can also allow `spaces`, `dash` and `underscore` characters.
 
 [note]
@@ -38,25 +41,22 @@ Can only be used only with the **string schema type**.
 
 ```ts
 {
-  username: schema.string({}, [
-    rules.alpha(),
-  ])
+  username: schema.string({}, [rules.alpha()])
 }
 
 // or
 rules.alpha({
-  allow: ['space', 'underscore', 'dash']
+  allow: ['space', 'underscore', 'dash'],
 })
 ```
 
 ## `rules.confirmed`
+
 Enforce the field under validation is also confirmed using the `_confirmation` convention. You will mostly use this rule for password confirmation.
 
 ```ts
 {
-  password: schema.string({}, [
-    rules.confirmed()
-  ])
+  password: schema.string({}, [rules.confirmed()])
 }
 
 /**
@@ -71,9 +71,7 @@ The `confirmed` rule also allows you to use a custom confirmation field name.
 
 ```ts
 {
-  password: schema.string({}, [
-    rules.confirmed('passwordConfirmation')
-  ])
+  password: schema.string({}, [rules.confirmed('passwordConfirmation')])
 }
 
 /**
@@ -85,6 +83,7 @@ The `confirmed` rule also allows you to use a custom confirmation field name.
 ```
 
 ## `rules.distinct`
+
 The `distinct` rule ensures that all values of a property inside an array are unique.
 
 Assuming you have an array of objects, each defining a product id property and you want to ensure that no duplicates product ids are being used.
@@ -139,8 +138,8 @@ You can also use the distinct rule with an array of literal values by using the 
 }
 ```
 
-
 ## `rules.email`
+
 Enforces the value to be properly formatted as an email.
 
 [note]
@@ -149,20 +148,18 @@ Can only be used only with the **string schema type**.
 
 ```ts
 {
-  email: schema.string({}, [
-    rules.email()
-  ])
+  email: schema.string({}, [rules.email()])
 }
 ```
 
 You can also define the following options to control the validation behavior.
 
-| Option | Default Value | Description |
-|--------|----------------|-------------|
-| allowIpDomain | `false` | Set it as `true` to allow IP addresses in the host part. |
-| ignoreMaxLength | `false` | Set it as `true` to disable email address max length validation. |
-| domainSpecificValidation | `false` | Set it as `true` to dis-allow certain syntactically valid email addresses that are rejected by **GMail** |
-| sanitize | `false` | Not a validation option, but instead can be used to transform the local part of the email (before the @ symbol) to all lowercase. |
+| Option                   | Default Value | Description                                                                                                                       |
+| ------------------------ | ------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| allowIpDomain            | `false`       | Set it as `true` to allow IP addresses in the host part.                                                                          |
+| ignoreMaxLength          | `false`       | Set it as `true` to disable email address max length validation.                                                                  |
+| domainSpecificValidation | `false`       | Set it as `true` to dis-allow certain syntactically valid email addresses that are rejected by **GMail**                          |
+| sanitize                 | `false`       | Not a validation option, but instead can be used to transform the local part of the email (before the @ symbol) to all lowercase. |
 
 ```ts
 {
@@ -170,12 +167,13 @@ You can also define the following options to control the validation behavior.
     rules.email({
       sanitize: true,
       ignoreMaxLength: true,
-    })
+    }),
   ])
 }
 ```
 
 ## `rules.exists`
+
 Enforces the value to exist in a database table.
 
 [note]
@@ -184,13 +182,12 @@ The validation rule is added by `@adonisjs/lucid` package. So make sure it is [i
 
 ```ts
 {
-  category_id: schema.number([
-    rules.exists({ table: 'categories', column: 'id' })
-  ])
+  category_id: schema.number([rules.exists({ table: 'categories', column: 'id' })])
 }
 ```
 
 ### Case insensitivity
+
 Many databases perform case sensitive queries. So whether you can transform the value to `lowerCase` in JavaScript or make use of the `caseInsensitive` option to convert value to lowercase during the query.
 
 ```ts
@@ -200,7 +197,7 @@ Many databases perform case sensitive queries. So whether you can transform the 
       table: 'users',
       column: 'username',
       caseInsensitive: true,
-    })
+    }),
   ])
 }
 
@@ -224,7 +221,7 @@ If you are caching your validation schema using the `cacheKey` and your **where 
       table: 'categories',
       column: 'id',
       where: { tenant_id: 1 },
-    })
+    }),
   ])
 }
 ```
@@ -233,10 +230,9 @@ Example with refs.
 
 ```ts
 class UserValidator {
-
   // highlight-start
   public refs = schema.refs({
-    tenantId: this.ctx.auth.user.tenantId
+    tenantId: this.ctx.auth.user.tenantId,
   })
   // highlight-end
 
@@ -248,14 +244,14 @@ class UserValidator {
         // highlight-start
         where: { tenant_id: this.refs.tenantId },
         // highlight-end
-      })
-    ])
+      }),
+    ]),
   })
-
 }
 ```
 
 ## `rules.unique`
+
 The `rules.unique` method is the opposite of `rules.exists` method. Instead of checking the existence of the value in a given table, it ensures the value doesn't exists.
 
 [note]
@@ -268,19 +264,18 @@ The validation rule is added by `@adonisjs/lucid` package. So make sure it is [i
     rules.unique({
       table: 'users',
       column: 'username',
-    })
+    }),
   ])
 }
 ```
 
 ## `rules.ip`
+
 Enforce the field under validation is a valid ip address. Optionally, you can also specify the `ip` version.
 
 ```ts
 {
-  ip: schema.string({}, [
-    rules.ip()
-  ])
+  ip: schema.string({}, [rules.ip()])
 }
 
 // or
@@ -290,13 +285,12 @@ rules.ip({
 ```
 
 ## `rules.maxLength`
+
 Limit the max length of a `string` or an `array`.
 
 ```ts
 {
-  username: schema.string({}, [
-    rules.maxLength(40)
-  ])
+  username: schema.string({}, [rules.maxLength(40)])
 }
 ```
 
@@ -304,83 +298,72 @@ You can also apply the `maxLength` rule on an array.
 
 ```ts
 {
-  tags: schema
-    .array([
-      rules.maxLength(10)
-    ])
-    .members(schema.string())
+  tags: schema.array([rules.maxLength(10)]).members(schema.string())
 }
 ```
 
 ## `rules.minLength`
+
 Enforce minimum length on a string or an array.
 
 ```ts
 {
-  tags: schema.array([
-    rules.minLength(1)
-  ])
+  tags: schema.array([rules.minLength(1)])
 }
 ```
 
 ## `rules.unsigned`
+
 Ensure, the value is an [unsigned integer](https://www.cs.utah.edu/~germain/PPS/Topics/unsigned_integer.html)
 
 ```ts
 {
-  age: schema.number([
-    rules.unsigned()
-  ])
+  age: schema.number([rules.unsigned()])
 }
 ```
 
 ## `rules.range`
+
 Ensure, the value is contained in the specified range.
+
 ```ts
 {
-  score: schema.number([
-    rules.range(0, 10)
-  ])
+  score: schema.number([rules.range(0, 10)])
 }
 ```
 
 ## `rules.regex`
+
 Define a custom regex to validate the value against.
 
 ```ts
 {
-  username: schema.string({}, [
-    rules.regex(/^[a-zA-Z0-9]+$/)
-  ])
+  username: schema.string({}, [rules.regex(/^[a-zA-Z0-9]+$/)])
 }
 ```
 
 ## `rules.uuid`
+
 Enforce the value of field under validation is a valid `uuid`. You can also optionally enforce a uuid version.
 
 ```ts
 {
-  id: schema.string({}, [
-    rules.uuid()
-  ])
+  id: schema.string({}, [rules.uuid()])
 }
 
 // Or enforce version
 {
-  id: schema.string({}, [
-    rules.uuid({ version: 4 })
-  ])
+  id: schema.string({}, [rules.uuid({ version: 4 })])
 }
 ```
 
 ## `rules.mobile`
+
 Enforces the value to be properly formatted as a phone number. You can also define locales for country specific validation.
 
 ```ts
 {
-  mobile: schema.string({}, [
-    rules.mobile()
-  ])
+  mobile: schema.string({}, [rules.mobile()])
 }
 ```
 
@@ -388,9 +371,7 @@ Validate against selected locales
 
 ```ts
 {
-  mobile: schema.string({}, [
-    rules.mobile({ locales: ['pt-BR', 'en-IN', 'en-US'] })
-  ])
+  mobile: schema.string({}, [rules.mobile({ locales: ['pt-BR', 'en-IN', 'en-US'] })])
 }
 ```
 
@@ -398,62 +379,59 @@ Also, you can enable **strict mode**, which will force the end user to specify t
 
 ```ts
 {
-  mobile: schema.string({}, [
-    rules.mobile({ strict: true })
-  ])
+  mobile: schema.string({}, [rules.mobile({ strict: true })])
 }
 ```
 
 ## `rules.requiredIfExists`
+
 Mark the current field as required, when **another field exists** and contains some value.
 
 ```ts
 {
-  password: schema.string.optional({}, [
-    rules.requiredIfExists('username')
-  ])
+  password: schema.string.optional({}, [rules.requiredIfExists('username')])
 }
 ```
 
 ## `rules.requiredIfExistsAll`
+
 Mark the current field as required, when **all of the other fields exists** and contains some value.
 
 ```ts
 {
-  password: schema.string.optional({}, [
-    rules.requiredIfExistsAll(['username', 'email'])
-  ])
+  password: schema.string.optional({}, [rules.requiredIfExistsAll(['username', 'email'])])
 }
 ```
 
 ## `rules.requiredIfExistsAny`
+
 Mark the current field as required, when **any of the other fields exists** and contains some value.
 
 ```ts
 {
-  password: schema.string.optional({}, [
-    rules.requiredIfExistsAny(['username', 'email'])
-  ])
+  password: schema.string.optional({}, [rules.requiredIfExistsAny(['username', 'email'])])
 }
 ```
 
 ## `rules.requiredIfNotExists`
+
 The opposite of [rules.requiredIfExists](#rulesrequiredifexists)
 
 ## `rules.requiredIfNotExistsAll`
+
 The opposite of [rules.requiredIfExistsAll](#rulesrequiredifexistsall)
 
 ## `rules.requiredIfNotExistsAny`
+
 The opposite of [rules.requiredIfExistsAny](#rulesrequiredifexistsany)
 
 ## `rules.requiredWhen`
+
 Mark the current field as required, when the value of the other field matches a given criteria.
 
 ```ts
 {
-  address: schema.string.optional({}, [
-    rules.requiredWhen('delivery_method', '=', 'shipping')
-  ])
+  address: schema.string.optional({}, [rules.requiredWhen('delivery_method', '=', 'shipping')])
 }
 ```
 
@@ -469,13 +447,12 @@ The `requiredWhen` rule support the following operators.
 - `<=`
 
 ## `rules.after`
+
 Ensure, the value of field is after a given date/offset. The rule can be only be used with the date data type.
 
 ```ts
 {
-  checkin_date: schema.date({}, [
-    rules.after(2, 'days')
-  ])
+  checkin_date: schema.date({}, [rules.after(2, 'days')])
 }
 ```
 
@@ -485,38 +462,35 @@ The `after` method can receive one of the following values:
 - The `today` or `tomorrow` keywords.
   ```ts
   {
-    checkin_date: schema.date({}, [
-      rules.after('tomorrow')
-    ])
+    checkin_date: schema.date({}, [rules.after('tomorrow')])
   }
   ```
 - Finally, you can also pass an instance of luxon DateTime object. Make sure, you pass it is a ref.
+
   ```ts
   class HolidayValidator {
     public refs = schema.refs({
-      allowedDate: luxon.DateTime.local().add({ days: '2' })
+      allowedDate: luxon.DateTime.local().add({ days: '2' }),
     })
 
     public schema = schema.create({
-      checkin_date: schema.date({}, [
-        rules.after(this.refs.allowedDate)
-      ])
+      checkin_date: schema.date({}, [rules.after(this.refs.allowedDate)]),
     })
   }
   ```
 
 ## `rules.before`
+
 Similar to `rules.after` but instead enforces the value be before the defined date/offset.
 
 ```ts
 {
-  joining_date: schema.date({}, [
-    rules.before('today')
-  ])
+  joining_date: schema.date({}, [rules.before('today')])
 }
 ```
 
 ## `rules.afterField`
+
 Similar to the `after` rule. But instead of defining a date/offset for comparison, you define the field to check against. For example:
 
 ```ts
@@ -540,6 +514,7 @@ Also, you can make use of the `afterOrEqualToField` for enforcing date to be sam
 ```
 
 ## `rules.beforeField`
+
 Similar to the `before` rule. But instead of defining a date/offset for comparison, you define the field to check against. For example:
 
 ```ts
@@ -563,28 +538,22 @@ Also, you can make use of the `beforeOrEqualToField` for enforcing date to be sa
 ```
 
 ## `rules.blacklist`
+
 Enforce the value of field is not inside the blacklist. The `blacklist` rule is opposite of the [enum schema type](/guides/validator/schema-types#schemaenum)
 
 ```ts
 {
-  username: schema.string({}, [
-    rules.blacklist([
-      'admin',
-      'super',
-      'root'
-    ])
-  ])
+  username: schema.string({}, [rules.blacklist(['admin', 'super', 'root'])])
 }
 ```
 
 ## `rules.url`
+
 Ensure the field under validation is a valid URL.
 
 ```ts
 {
-  website: schema.string({}, [
-    rules.url()
-  ])
+  website: schema.string({}, [rules.url()])
 }
 ```
 
@@ -594,8 +563,8 @@ Along with the format validation, you can also enforce the url to be from a cert
 {
   twitterProfile: schema.string({}, [
     rules.url({
-      hostWhitelist: ['twitter.com']
-    })
+      hostWhitelist: ['twitter.com'],
+    }),
   ])
 }
 ```
@@ -606,16 +575,14 @@ Or use the `hostBlacklist` option to disallow certain hosts.
 {
   website: schema.string({}, [
     rules.url({
-      hostBlacklist: [
-        'acme.com',
-        'example.com'
-      ]
-    })
+      hostBlacklist: ['acme.com', 'example.com'],
+    }),
   ])
 }
 ```
 
 ### Validation options
+
 Following is the list of all the validation options.
 
 ```ts
@@ -623,18 +590,19 @@ Following is the list of all the validation options.
   website: schema.string({}, [
     rules.url({
       protocols: ['http', 'https'],
-      requireTld: true
-      requireProtocol: false
-      requireHost: true
-      hostWhitelist: []
-      hostBlacklist: []
-      validateLength: false
-    })
+      requireTld: true,
+      requireProtocol: false,
+      requireHost: true,
+      hostWhitelist: [],
+      hostBlacklist: [],
+      validateLength: false,
+    }),
   ])
 }
 ```
 
 ### Normalization options
+
 Along with the validation, you can also use the following options to normalize urls.
 
 ```ts
@@ -643,7 +611,7 @@ Along with the validation, you can also use the following options to normalize u
     rules.url({
       ensureProtocol: 'https',
       stripWWW: true,
-    })
+    }),
   ])
 }
 ```


### PR DESCRIPTION
I think there are just missing commas there: https://preview.adonisjs.com/guides/validator/rules#validation-options (in the options object)