### PR TITLE
Documentation: Add missing commas to validation

### DIFF
--- a/docs/docs/guides/validator/04-validation-rules.md
+++ b/docs/docs/guides/validator/04-validation-rules.md
@@ -623,11 +623,11 @@ Following is the list of all the validation options.
   website: schema.string({}, [
     rules.url({
       protocols: ['http', 'https'],
-      requireTld: true
-      requireProtocol: false
-      requireHost: true
-      hostWhitelist: []
-      hostBlacklist: []
+      requireTld: true,
+      requireProtocol: false,
+      requireHost: true,
+      hostWhitelist: [],
+      hostBlacklist: [],
       validateLength: false
     })
   ])


### PR DESCRIPTION
I think there are just missing commas there: https://preview.adonisjs.com/guides/validator/rules#validation-options (in the options object)